### PR TITLE
fullpath support for object and asset listings

### DIFF
--- a/src/GraphQL/Query/QueryType.php
+++ b/src/GraphQL/Query/QueryType.php
@@ -258,6 +258,7 @@ class QueryType extends ObjectType
                 'name' => 'get' . $ucFirstClassName . 'Listing',
                 'args' => [
                     'ids' => ['type' => Type::string()],
+                    'fullpaths' => ['type' => Type::string()],
                     'defaultLanguage' => ['type' => Type::string()],
                     'first' => ['type' => Type::int()],
                     'after' => ['type' => Type::int()],
@@ -334,6 +335,7 @@ class QueryType extends ObjectType
             'name' => 'getAssetListing',
             'args' => [
                 'ids' => ['type' => Type::string()],
+                'fullpaths' => ['type' => Type::string()],
                 'defaultLanguage' => ['type' => Type::string()],
                 'first' => ['type' => Type::int()],
                 'after' => ['type' => Type::int()],


### PR DESCRIPTION
The fullpath handling in AssetListing::resolveListing and QueryType::resolveListing is currently duplicated. There are multiple reasons why I decided to not merge it yet:
- the entire function is more or less duplicated
- there is no existing instance, class or trait where it would fit in
- the current code structure is not really meant to be extended by a small helper class for fullpath